### PR TITLE
Enable import of journal entries by month

### DIFF
--- a/app/Console/Commands/ImportJournalEntriesCommand.php
+++ b/app/Console/Commands/ImportJournalEntriesCommand.php
@@ -13,12 +13,25 @@ use Illuminate\Support\Facades\DB;
 
 class ImportJournalEntriesCommand extends Command
 {
+    const MONTH_URLS = [
+        8 => 'https://fromthepage.com/export/show?work_id=18351',
+        9 => 'https://fromthepage.com/export/show?work_id=18350',
+        10 => 'https://fromthepage.com/export/show?work_id=17469',
+        11 => 'https://fromthepage.com/export/show?work_id=17471',
+        12 => 'https://fromthepage.com/export/show?work_id=17501',
+    ];
+
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'journal:import {path : path to a fromthepage.com XHTML export}';
+    protected $signature = '
+                            journal:import
+                            {month?* : Months to import (e.g. 10 11)}
+                            {--all : Imports all months (same as 8 9 10 11 12)}
+                            {--path= : Path to a local export}
+                            ';
 
     /**
      * The console command description.
@@ -44,7 +57,39 @@ class ImportJournalEntriesCommand extends Command
      */
     public function handle()
     {
-        $journal = new JournalParser(file_get_contents($this->argument('path')));
+        $months = $this->argument('month');
+
+        if ($this->option('path'))
+        {
+            $this->importJournalEntries($this->option('path'));
+            return;
+        }
+
+        if (empty($months))
+        {
+            $this->error('You did not enter a month or a local path');
+            return 1;
+        }
+
+        foreach ($months as $month)
+        {
+            if (!array_key_exists($month, self::MONTH_URLS))
+            {
+                $this->error('Unknown month "' . $month  .'". Valid values: ' . join(" ", array_keys(self::MONTH_URLS)));
+                return 1;
+            }
+        }
+
+        foreach ($months as $month)
+        {
+            $this->info("Importing month {$month}");
+            $this->importJournalEntries(self::MONTH_URLS[$month]);
+        }
+    }
+
+    private function importJournalEntries($url)
+    {
+        $journal = new JournalParser(file_get_contents($url));
         $parsedJournal = $journal->parse();
 
         $this->updateOrCreateTagCategories($parsedJournal->tag_categories);

--- a/app/JournalParser.php
+++ b/app/JournalParser.php
@@ -145,11 +145,11 @@ class JournalDOMElement extends DOMElement
     public function getParsedDate()
     {
         $trimmed = preg_replace('/\s/', '', $this->textContent);
-        $trimmed = str_replace('.VIII.', '.9.', $trimmed);
+        $trimmed = str_replace('.VIII.', '.8.', $trimmed);
         $trimmed = str_replace('.IX.', '.9.', $trimmed);
         $trimmed = str_replace('.X.',  '.10.', $trimmed);
         $trimmed = str_replace('.XI.', '.11.', $trimmed);
-        $trimmed = str_replace('.XII.', '.11.', $trimmed);
+        $trimmed = str_replace('.XII.', '.12.', $trimmed);
 
         return Carbon::createFromFormat('d.m.Y', $trimmed);
     }

--- a/app/JournalParser.php
+++ b/app/JournalParser.php
@@ -145,9 +145,11 @@ class JournalDOMElement extends DOMElement
     public function getParsedDate()
     {
         $trimmed = preg_replace('/\s/', '', $this->textContent);
+        $trimmed = str_replace('.VIII.', '.9.', $trimmed);
         $trimmed = str_replace('.IX.', '.9.', $trimmed);
         $trimmed = str_replace('.X.',  '.10.', $trimmed);
         $trimmed = str_replace('.XI.', '.11.', $trimmed);
+        $trimmed = str_replace('.XII.', '.11.', $trimmed);
 
         return Carbon::createFromFormat('d.m.Y', $trimmed);
     }

--- a/tests/Feature/ImportJournalEntriesCommandTest.php
+++ b/tests/Feature/ImportJournalEntriesCommandTest.php
@@ -35,6 +35,6 @@ class ImportJournalEntriesCommandTest extends TestCase
     }
 
     private function runCommand() {
-        $this->artisan('journal:import', ['path' => 'tests/Fixtures/journal-transcription-10-1989.html']);
+        $this->artisan('journal:import', ['--path' => 'tests/Fixtures/journal-transcription-10-1989.html']);
     }
 }


### PR DESCRIPTION
As an admin, I want to be able to re-import a month of journal entries without exporting it to a file

Example usage:

```bash
php artisan journal journal:import 10 11
```
to import October and November entries