### PR TITLE
Disable touch drag for calendar

### DIFF
--- a/resources/js/components/RowView.vue
+++ b/resources/js/components/RowView.vue
@@ -14,6 +14,7 @@
       :scrollPerPage="false"
       :paginationEnabled="false"
       :mouseDrag="false"
+      :touchDrag="false"
       :perPage="perPage"
     >
       <slide v-for="(day, i) in days" :key="day.d">


### PR DESCRIPTION
The trade-off here is that on screen widths < 425px, you can only move by one day. But that's still better than swiping that is not working at all on my Android phone.