### PR TITLE
use card-columns in topic detail

### DIFF
--- a/resources/js/topic.js
+++ b/resources/js/topic.js
@@ -1,28 +1,31 @@
 window.repositionItems = function() {
+  var DEFAULT_CONTAINER_WIDTH = 1280;
+  if ( $(window).width() >= DEFAULT_CONTAINER_WIDTH ) {
 
-  var ratio = $( window ).width() / 1280;
+    var ratio = $( window ).width() / DEFAULT_CONTAINER_WIDTH;
 
-  $( '.item-container' ).each(function( index ) {
-    var height = $(this).data('orig-height') || 0;
-    $(this).css("height", height * ratio);
-  });
+    $( '.item-container' ).each(function( index ) {
+      var height = $(this).data('orig-height') || 0;
+      $(this).css("height", height * ratio);
+    });
 
-  $( '.item' ).each(function( index ) {
-    var width = $(this).data('orig-width') || 0;
-    var height = $(this).data('orig-height') || 0;
+    $( '.item' ).each(function( index ) {
+      var width = $(this).data('orig-width') || 0;
+      var height = $(this).data('orig-height') || 0;
 
-    var x = (parseFloat($(this).data('orig-x')) || 0) * ratio;
-    var y = (parseFloat($(this).data('orig-y')) || 0) * ratio;
+      var x = (parseFloat($(this).data('orig-x')) || 0) * ratio;
+      var y = (parseFloat($(this).data('orig-y')) || 0) * ratio;
 
-    $(this).css("height", height * ratio);
-    $(this).css("width", width * ratio);
+      $(this).css("height", height * ratio);
+      $(this).css("width", width * ratio);
 
-    $(this).css("left", x + 'px');
-    $(this).css("top", y + 'px');
+      $(this).css("left", x + 'px');
+      $(this).css("top", y + 'px');
 
-    $(this).attr('data-x', x)
-    $(this).attr('data-y', y)
+      $(this).attr('data-x', x)
+      $(this).attr('data-y', y)
 
-  });
+    });
+  }
 }
 

--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -52,3 +52,20 @@ $grid-gutter-width: 2rem;
 $background-shift: 0.5rem;
 $ruled-paper-line-height: 2rem;
 $overlay-color: rgba($black, 0.35);
+
+
+// Cards
+$card-spacer-y:                     .75rem;
+$card-spacer-x:                     1.25rem;
+$card-border-width:                 0;
+$card-border-radius:                0;
+$card-border-color:                 rgba($black, .125);
+$card-inner-border-radius:          0;
+$card-cap-bg:                       transparent;
+$card-cap-color:                    null;
+$card-color:                        null;
+$card-bg:                           transparent;
+
+$card-columns-count:                2;
+$card-columns-gap:                  1.25rem;
+$card-columns-margin:               $card-spacer-y;

--- a/resources/sass/topics.scss
+++ b/resources/sass/topics.scss
@@ -126,8 +126,16 @@
             z-index: 10;
         }
 
-        @media(max-width: 720px) {
+        &.card-columns {
+          // @include media-breakpoint-down(md) {
+          //   column-count: 1;
+          // }
+          @media(min-width: 1280px) {
+            column-count: 1;
+          }
+        }
 
+        @media(max-width: 1279px) {
             .item-container {
                 height: auto !important;
             }

--- a/resources/views/layouts/topic.blade.php
+++ b/resources/views/layouts/topic.blade.php
@@ -52,7 +52,7 @@
 
     @yield('before-items')
 
-    <div id="items">
+    <div id="items" class="card-columns">
         @yield('items')
     </div>
 

--- a/resources/views/topics/show.blade.php
+++ b/resources/views/topics/show.blade.php
@@ -2,7 +2,7 @@
 
 @section('items')
     @foreach ($topic->items as $i=>$item)
-        <div class="item-container item-type-{{ $item->type }}" style="height: {{$item->pivot->container}}px" data-orig-height="{{$item->pivot->container}}" >
+        <div class="card item-container item-type-{{ $item->type }}" style="height: {{$item->pivot->container}}px" data-orig-height="{{$item->pivot->container}}" >
 
             @if ($item->file && $item->type != 'slogan')
                 <a href="{{ asset($item->file) }}" class="image-link" title="{{ $item->full_name }}" data-text="{{ $item->text }}">


### PR DESCRIPTION
break items in topic detail into two columns masonry-like-grid using 
bootstrap's `.card-columns` https://getbootstrap.com/docs/4.1/components/card/#card-columns
![Screenshot 2019-12-03 at 12 07 51](https://user-images.githubusercontent.com/2682941/70046164-bf460880-15c5-11ea-869d-fe8b37ebc202.png)
