### PR TITLE
fix missing app.es5.js in master.blade.php

### DIFF
--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -51,7 +51,7 @@
     </div>
   <script type="text/javascript" src="{{ mix('/js/manifest.js') }}"></script>
   <script type="text/javascript" src="{{ mix('/js/vendor.js') }}"></script>
-  <script type="text/javascript" src="{{ mix('/js/app.es5.js') }}"></script>
+  <script type="text/javascript" src="{{ mix('/js/app.js') }}"></script>
 
   @stack('scripts')
 


### PR DESCRIPTION
javascript stoped working after requesting ` mix('/js/app.es5.js')` instead of `mix('/js/app.js')`

@martin-havala please double check how to get `app.es5.js`

meanwhile here is the temporary fix. 