### PR TITLE
Webumenia 1202 mobile spacings and typo

### DIFF
--- a/resources/sass/_backgrounds.scss
+++ b/resources/sass/_backgrounds.scss
@@ -1,5 +1,8 @@
 .file-paper {
-    @include paper-bck(3rem);
+    @include paper-bck(2rem);
+    @include media-breakpoint-up(sm) {
+        @include paper-bck(3rem);
+    }
     &::before {
         @extend %before-after-sizing;
         @extend %file-paper-bgr;

--- a/resources/sass/_components.scss
+++ b/resources/sass/_components.scss
@@ -67,9 +67,21 @@
     }
 
     & .item-text {
-        padding-left: 4em;
-        padding-top: 2em;
+        padding-left: 1em;
+        padding-top: 1em;
         padding-right: 1em;
+
+        @include media-breakpoint-up(sm) {
+            padding-left: 2em;
+            padding-top: 1em;
+            padding-right: 1em;
+        }
+
+        @include media-breakpoint-up(lg) {
+            padding-left: 4em;
+            padding-top: 2em;
+            padding-right: 1em;
+        }
 
         .item-text-read-more-link {
             .btn-link {

--- a/resources/sass/_mixins.scss
+++ b/resources/sass/_mixins.scss
@@ -18,8 +18,12 @@
 %file-paper-bgr {
     background-image: url("/images/file-paper.svg");
     background-repeat: repeat-y;
-    background-size: 3rem auto;
-    width: 3rem;
+    background-size: 2rem auto;
+    width: 2rem;
+    @include media-breakpoint-up(sm) {
+        background-size: 3rem auto;
+        width: 3rem;
+    }
 }
 
 %tableau-paper-bgr {

--- a/resources/sass/_typography.scss
+++ b/resources/sass/_typography.scss
@@ -6,3 +6,10 @@ h1 {
     font-size: 5.25em;
   }
 }
+
+h3 {
+  font-size: 1.8em;
+  @include media-breakpoint-up(md) {
+    font-size: $h3-font-size;
+  }
+}

--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -41,6 +41,15 @@ $theme-colors: (
 
 $text-muted: $gray;
 
+$grid-breakpoints: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+  xxl: 1600px
+);
+
 // Navbar
 $navbar-dark-color: rgba($white, 0.5);
 $navbar-light-color: rgba($black, 0.5);

--- a/resources/sass/topics.scss
+++ b/resources/sass/topics.scss
@@ -16,6 +16,12 @@
 #topic {
     background-color: $gray-light;
 
+    @include media-breakpoint-up(xxl) {
+        p, .item-image-description {
+            font-size: 1.2em;
+        }
+    }
+
     .header {
         #title-container {
             min-height: 40vh;

--- a/resources/views/layouts/topic.blade.php
+++ b/resources/views/layouts/topic.blade.php
@@ -45,7 +45,7 @@
         </div>
         <div id="description-container" class="container position-relative">
             <div class="row">
-                <div id="description" class="offset-lg-3 col-lg-6 file-paper text-left pt-4 pr-5">
+                <div id="description" class="offset-lg-3 col-lg-6 file-paper text-left pt-4 pr-4 pr-md-5">
                     {!! parsedown($topic->description) !!}
                 </div>
             </div>


### PR DESCRIPTION
fixes too large spaces spaces in topic on mobile + bit smaller typography 
before / after:
![Screenshot 2019-12-20 at 09 56 37](https://user-images.githubusercontent.com/2682941/71244263-6939ca80-2312-11ea-9e57-5e0d953243ab.png)
![Screenshot 2019-12-20 at 09 56 50](https://user-images.githubusercontent.com/2682941/71244264-6939ca80-2312-11ea-803f-f05cd97fc057.png)
![Screenshot 2019-12-20 at 09 57 14](https://user-images.githubusercontent.com/2682941/71244266-69d26100-2312-11ea-9140-d54d2e3cfc81.png)
![Screenshot 2019-12-20 at 09 57 22](https://user-images.githubusercontent.com/2682941/71244267-69d26100-2312-11ea-8f00-0bd6e1b97488.png)
![Screenshot 2019-12-20 at 09 57 40](https://user-images.githubusercontent.com/2682941/71244268-69d26100-2312-11ea-8da2-29a03c8b122e.png)
![Screenshot 2019-12-20 at 09 57 53](https://user-images.githubusercontent.com/2682941/71244270-6a6af780-2312-11ea-903a-fc96f2f125f5.png)

+ add larger typo for XXL screens + add new breakpoint `xxl` for screens > 1600px

![Screenshot 2019-12-20 at 10 18 00](https://user-images.githubusercontent.com/2682941/71244306-7eaef480-2312-11ea-90d5-50ad5b69f2fc.png)
![Screenshot 2019-12-20 at 10 18 09](https://user-images.githubusercontent.com/2682941/71244307-7f478b00-2312-11ea-9ce4-76f2d06ac856.png)
